### PR TITLE
Add tests for docker events and console notifier

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,24 @@
+name: Go Tests
+
+on:
+  push:
+    branches: [ main, master ] # Adjust if your main branch has a different name
+  pull_request:
+    branches: [ main, master ] # Adjust if your main branch has a different name
+
+jobs:
+  test:
+    name: Run Go Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4 # Switched to v4 for latest features/fixes
+
+    - name: Set up Go
+      uses: actions/setup-go@v5 # Switched to v5 for latest features/fixes
+      with:
+        go-version: '1.23' # Specify your project's Go version
+
+    - name: Run tests
+      run: go test -v ./... # -v for verbose output, ./... to run all tests

--- a/internal/docker/events_test.go
+++ b/internal/docker/events_test.go
@@ -1,0 +1,134 @@
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDockerEventsClient is a helper struct to mock the DockerAPIClient for events_test.go
+type mockDockerEventsClient struct {
+	mockDockerClient // Embed the mock from client_test.go if common methods are needed
+	eventsFunc       func(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error)
+}
+
+// Overriding the Events method from the embedded mockDockerClient if necessary,
+// or just implementing it if mockDockerClient doesn't have it.
+func (m *mockDockerEventsClient) Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
+	if m.eventsFunc != nil {
+		return m.eventsFunc(ctx, options)
+	}
+	// Default behavior if not set by a specific test
+	msgChan := make(chan events.Message)
+	errChan := make(chan error)
+	// Close channels immediately for tests not expecting events, or handle as per test needs.
+	// Consider if tests need to send dummy events or errors through these channels.
+	// close(msgChan)
+	// close(errChan)
+	return msgChan, errChan
+}
+
+// Ensure mockDockerEventsClient implements DockerAPIClient.
+// We might need to add other methods from DockerAPIClient if StreamEvents or its setup calls them.
+// For now, assuming only Events() and Close() (from embedded mockDockerClient) are relevant.
+var _ DockerAPIClient = (*mockDockerEventsClient)(nil)
+
+func TestStreamEvents(t *testing.T) {
+	t.Run("successful event stream without filters", func(t *testing.T) {
+		actualMockedEventsChan := make(chan events.Message)
+		actualMockedErrorsChan := make(chan error)
+		defer close(actualMockedEventsChan)
+		defer close(actualMockedErrorsChan)
+
+		var expectedEventsChan <-chan events.Message = actualMockedEventsChan
+		var expectedErrorsChan <-chan error = actualMockedErrorsChan
+
+		mockAPIClient := &mockDockerEventsClient{
+			eventsFunc: func(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
+				// Check that filters are empty
+				assert.Equal(t, 0, options.Filters.Len(), "Expected no filters to be set")
+				return actualMockedEventsChan, actualMockedErrorsChan
+			},
+		}
+
+		// Create our Docker client with the mocked API client
+		c := &Client{cli: mockAPIClient}
+
+		eventStream, err := c.StreamEvents(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, eventStream)
+
+		assert.Equal(t, expectedEventsChan, eventStream.Events, "Events channel does not match")
+		assert.Equal(t, expectedErrorsChan, eventStream.Errors, "Errors channel does not match")
+	})
+
+	t.Run("successful event stream with filters", func(t *testing.T) {
+		actualMockedEventsChan := make(chan events.Message)
+		actualMockedErrorsChan := make(chan error)
+		defer close(actualMockedEventsChan)
+		defer close(actualMockedErrorsChan)
+
+		var expectedEventsChan <-chan events.Message = actualMockedEventsChan
+		var expectedErrorsChan <-chan error = actualMockedErrorsChan
+
+		expectedFilters := filters.NewArgs()
+		expectedFilters.Add("type", "container")
+
+		mockAPIClient := &mockDockerEventsClient{
+			eventsFunc: func(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
+				// Check that filters are set as expected
+				assert.True(t, options.Filters.ExactMatch("type", "container"), "Expected 'type' filter to be 'container'")
+				return actualMockedEventsChan, actualMockedErrorsChan
+			},
+		}
+
+		c := &Client{cli: mockAPIClient}
+
+		eventStream, err := c.StreamEvents(context.Background(), expectedFilters)
+		require.NoError(t, err)
+		require.NotNil(t, eventStream)
+
+		assert.Equal(t, expectedEventsChan, eventStream.Events, "Events channel does not match")
+		assert.Equal(t, expectedErrorsChan, eventStream.Errors, "Errors channel does not match")
+	})
+
+	t.Run("event stream with multiple filter arguments", func(t *testing.T) {
+		// This test verifies that only the first filterArgs is used, as per implementation.
+		actualMockedEventsChan := make(chan events.Message)
+		actualMockedErrorsChan := make(chan error)
+		defer close(actualMockedEventsChan)
+		defer close(actualMockedErrorsChan)
+		// Not asserting channel equality here as the main point is to check filter passing.
+		// var expectedEventsChan <-chan events.Message = actualMockedEventsChan
+		// var expectedErrorsChan <-chan error = actualMockedErrorsChan
+		
+		filters1 := filters.NewArgs()
+		filters1.Add("event", "start")
+
+		filters2 := filters.NewArgs() // This should be ignored by StreamEvents
+		filters2.Add("event", "stop")
+
+
+		mockAPIClient := &mockDockerEventsClient{
+			eventsFunc: func(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error) {
+				assert.True(t, options.Filters.ExactMatch("event", "start"), "Expected 'event' filter to be 'start'")
+				assert.False(t, options.Filters.ExactMatch("event", "stop"), "Filter 'stop' should not be present")
+				return actualMockedEventsChan, actualMockedErrorsChan
+			},
+		}
+		c := &Client{cli: mockAPIClient}
+		_, err := c.StreamEvents(context.Background(), filters1, filters2)
+		require.NoError(t, err)
+
+	})
+}
+
+// It might be necessary to define a Close() method on mockDockerEventsClient
+// if the Client's Close() method is ever called, or if other parts of the system expect it.
+// If mockDockerClient (embedded) already provides a no-op Close(), this is fine.
+// func (m *mockDockerEventsClient) Close() error { return nil }

--- a/internal/docker/events_test.go
+++ b/internal/docker/events_test.go
@@ -26,10 +26,9 @@ func (m *mockDockerEventsClient) Events(ctx context.Context, options types.Event
 	// Default behavior if not set by a specific test
 	msgChan := make(chan events.Message)
 	errChan := make(chan error)
-	// Close channels immediately for tests not expecting events, or handle as per test needs.
-	// Consider if tests need to send dummy events or errors through these channels.
-	// close(msgChan)
-	// close(errChan)
+	// Close channels immediately for tests not expecting events.
+	close(msgChan)
+	close(errChan)
 	return msgChan, errChan
 }
 

--- a/internal/notifications/console_test.go
+++ b/internal/notifications/console_test.go
@@ -1,0 +1,170 @@
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureOutput captures log output for testing.
+// It returns a function that should be called (e.g., with defer) to restore the original log output
+// and return the captured string.
+func captureOutput(t *testing.T) (*bytes.Buffer, func() string) {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetFlags(0) // Remove timestamp and other prefixes for predictable output
+
+	// It's important to guard access to the buffer if tests run in parallel,
+	// though for these specific tests, they modify a global (log.SetOutput)
+	// so parallel execution of tests that use this function is problematic.
+	// For simplicity, assuming tests using this are run serially or one at a time.
+	// If parallel tests are needed, each test would need its own logger instance.
+
+	return &buf, func() string {
+		log.SetOutput(os.Stderr) // Restore default logger
+		return buf.String()
+	}
+}
+
+func TestNewConsoleNotifier(t *testing.T) {
+	t.Run("default prefix", func(t *testing.T) {
+		notifier := NewConsoleNotifier("")
+		assert.Equal(t, "DOCKER-EVENT", notifier.prefix, "Expected default prefix")
+		assert.False(t, notifier.colored, "Expected colored to be false by default")
+	})
+
+	t.Run("custom prefix", func(t *testing.T) {
+		notifier := NewConsoleNotifier("CUSTOM_PREFIX")
+		assert.Equal(t, "CUSTOM_PREFIX", notifier.prefix, "Expected custom prefix")
+		assert.False(t, notifier.colored, "Expected colored to be false")
+	})
+
+	t.Run("with color option", func(t *testing.T) {
+		notifier := NewConsoleNotifier("", WithColor())
+		assert.True(t, notifier.colored, "Expected colored to be true with WithColor option")
+	})
+
+	t.Run("custom prefix and with color option", func(t *testing.T) {
+		notifier := NewConsoleNotifier("MY_EVENTS", WithColor())
+		assert.Equal(t, "MY_EVENTS", notifier.prefix, "Expected custom prefix")
+		assert.True(t, notifier.colored, "Expected colored to be true")
+	})
+}
+
+func TestConsoleNotifier_Notify(t *testing.T) {
+	sampleEvent := Event{
+		Type:   "container",
+		Action: "start",
+		Name:   "test-container",
+		Image:  "test-image:latest",
+	}
+
+	t.Run("notify without color", func(t *testing.T) {
+		_, cleanup := captureOutput(t)
+		defer cleanup()
+
+		notifier := NewConsoleNotifier("TEST")
+		err := notifier.Notify(context.Background(), sampleEvent, false)
+		require.NoError(t, err)
+
+		output := cleanup()
+		expectedLog := "[TEST] container start test-container (test-image:latest)"
+		// Trim newline which log.Print adds
+		assert.Equal(t, expectedLog, strings.TrimSpace(output))
+	})
+
+	t.Run("notify with color", func(t *testing.T) {
+		_, cleanup := captureOutput(t)
+		defer cleanup()
+
+		notifier := NewConsoleNotifier("COLORTEST", WithColor())
+		err := notifier.Notify(context.Background(), sampleEvent, false)
+		require.NoError(t, err)
+
+		output := cleanup()
+		// Check for prefix and parts of the ANSI output. Exact ANSI codes can be brittle.
+		assert.Contains(t, output, "[COLORTEST]")
+		assert.Contains(t, output, sampleEvent.Name) // Name should be in the output
+		assert.Contains(t, output, Yellow)           // Action should be yellow
+		assert.Contains(t, output, Cyan)              // Name should be cyan
+		assert.Contains(t, output, Green)             // Image should be green
+		assert.Contains(t, output, Reset)             // Reset code should be present
+	})
+
+	t.Run("notify with custom message", func(t *testing.T) {
+		_, cleanup := captureOutput(t)
+		defer cleanup()
+
+		customMessageEvent := Event{
+			Message: "This is a custom message",
+		}
+		notifier := NewConsoleNotifier("CUSTOM")
+		err := notifier.Notify(context.Background(), customMessageEvent, false)
+		require.NoError(t, err)
+		output := cleanup()
+		expectedLog := "[CUSTOM] This is a custom message"
+		assert.Equal(t, expectedLog, strings.TrimSpace(output))
+	})
+}
+
+// TestConsoleNotifier_NotifyMultiple tests the NotifyMultiple method
+func TestConsoleNotifier_NotifyMultiple(t *testing.T) {
+	event1 := Event{Type: "container", Action: "start", Name: "c1", Image: "img1"}
+	event2 := Event{Type: "container", Action: "stop", Name: "c2", Image: "img2"}
+
+	t.Run("notify multiple without color", func(t *testing.T) {
+		_, cleanup := captureOutput(t)
+		defer cleanup()
+
+		notifier := NewConsoleNotifier("MULTI")
+		err := notifier.NotifyMultiple(context.Background(), []Event{event1, event2}, false)
+		require.NoError(t, err)
+
+		output := cleanup()
+		// log.Print adds a newline for each call
+		expectedLogs := "[MULTI] container start c1 (img1)\n[MULTI] container stop c2 (img2)"
+		assert.Equal(t, expectedLogs, strings.TrimSpace(output))
+	})
+
+	t.Run("notify multiple with color", func(t *testing.T) {
+		_, cleanup := captureOutput(t)
+		defer cleanup()
+
+		notifier := NewConsoleNotifier("COLORMULTI", WithColor())
+		err := notifier.NotifyMultiple(context.Background(), []Event{event1, event2}, false)
+		require.NoError(t, err)
+
+		output := cleanup()
+		assert.Contains(t, output, "[COLORMULTI]")
+		assert.Contains(t, output, "c1")
+		assert.Contains(t, output, "c2")
+		assert.Contains(t, output, Yellow) // Check for color codes
+		assert.Contains(t, output, Reset)
+	})
+
+	t.Run("notify multiple with empty slice", func(t *testing.T) {
+		_, cleanup := captureOutput(t)
+		defer cleanup()
+
+		notifier := NewConsoleNotifier("EMPTY")
+		err := notifier.NotifyMultiple(context.Background(), []Event{}, false)
+		require.NoError(t, err)
+
+		output := cleanup()
+		assert.Equal(t, "", strings.TrimSpace(output), "Expected no log output for empty event slice")
+	})
+}
+
+// Note: The init() function in notification.go which parses templates
+// might panic if templates are invalid. If these tests fail,
+// ensure that the templates in notification.go are correct.
+// However, console_notifier specifically uses event.Text() and event.ANSI(),
+// so direct template issues from notification.go's init() might not surface here
+// unless those methods fail.


### PR DESCRIPTION
This commit introduces new test suites for two previously untested areas:

1.  `internal/docker/events.go`:
    *   Added `internal/docker/events_test.go`.
    *   Tests for `StreamEvents` function, covering scenarios with and without event filters.
    *   Utilizes a mock Docker API client to ensure isolated and reliable testing of event streaming logic.

2.  `internal/notifications/console.go`:
    *   Added `internal/notifications/console_test.go`.
    *   Tests for `NewConsoleNotifier` constructor, including prefix handling and color options.
    *   Tests for the `Notify` method, verifying correct log output formatting for both standard and colored messages by capturing log output.
    *   Tests for the `NotifyMultiple` method, ensuring all events in a batch are processed and logged correctly.

These tests improve code coverage and provide greater confidence in the reliability of event handling and notification functionalities.